### PR TITLE
Stack getting stuck

### DIFF
--- a/lib/project/handler.js
+++ b/lib/project/handler.js
@@ -38,7 +38,11 @@ module.exports = function handler(event,context) {
   if (!_.includes(getDirectories(resourcePath), resourceType))
     return util.done("Invalid resourceType:" + resourceType, ev, context);
 
-  require(path.join(resourcePath,resourceType)).handler(ev,context);
+  try {
+    require(path.join(resourcePath, resourceType)).handler(ev, context);
+  } catch(e) {
+    util.done(e,ev,context);
+  }
 };
 
 function getDirectories(srcpath) {

--- a/test/fixtures/project1/lib/resources/resource3/create.js
+++ b/test/fixtures/project1/lib/resources/resource3/create.js
@@ -1,0 +1,15 @@
+var create = require('../../../../../../lib/resource/create')
+util = require('../../../../../../lib/util');
+
+module.exports.handler = function(event,context) {
+    create.apply(this,[event,context,myCreate]);
+};
+
+var myCreate = function(err,event,context) {
+    if (err)
+        return util.done(err);
+
+    dont_fail_badly();
+
+    util.done(null,event,context,{id: 1, name: "First Resource"},1);
+};

--- a/test/fixtures/project1/lib/resources/resource3/delete.js
+++ b/test/fixtures/project1/lib/resources/resource3/delete.js
@@ -1,0 +1,7 @@
+var destroy = require('../../../../../../lib/resource/delete')
+  util = require('../../../../../../lib/util');
+
+// Bad function, no callback
+module.exports.handler = function(event, context) {
+  destroy.apply(this, [event, context]);
+};

--- a/test/fixtures/project1/lib/resources/resource3/index.js
+++ b/test/fixtures/project1/lib/resources/resource3/index.js
@@ -1,0 +1,5 @@
+var handler = require('../../../../../../lib/resource/handler');
+
+module.exports.handler = function() {
+  handler.apply(this,arguments);
+};

--- a/test/fixtures/project1/lib/resources/resource3/update.js
+++ b/test/fixtures/project1/lib/resources/resource3/update.js
@@ -1,0 +1,7 @@
+var update = require('../../../../../../lib/resource/update')
+  util = require('../../../../../../lib/util');
+
+// Bad function, no callback
+module.exports.handler = function(event, context) {
+  update.apply(this, [event, context]);
+};

--- a/test/integration/project1/project.test.js
+++ b/test/integration/project1/project.test.js
@@ -261,5 +261,27 @@ describe('project1', function() {
         });
       });
     });
+
+    describe("resource3", function() {
+
+      describe("create", function() {
+
+        it("should run without error", function(cb) {
+          var event = {
+            resourceType: "resource3",
+            requestType: "create"
+          };
+
+          var context = {
+            done: function(err,data,id) {
+              assert.equal(err, 'ReferenceError: dont_fail_badly is not defined');
+              cb();
+            }
+          };
+          project1.handler(event,context);
+        });
+      });
+
+    });
   });
 });


### PR DESCRIPTION
Our Cloudformation stacks get stuck for 1 hour if the javascript code contains errors. In order to prevent this lambda-formation should catch errors on project level and information CF.

Example:
```
2017-05-16T04:41:28.643Z    c47b3600-39f1-11e7-ae9c-e103c4f2d375    ReferenceError: aws is not defined
at update (/var/task/lib/resources/HostedZone/update.js:10:23)
at Object.module.exports (/var/task/node_modules/lambda-formation/lib/resource/update.js:16:12)
at Object.module.exports.handler (/var/task/lib/resources/HostedZone/update.js:24:13)
at Object.module.exports (/var/task/node_modules/lambda-formation/lib/resource/handler.js:36:24)
at Object.module.exports.handler (/var/task/lib/resources/HostedZone/index.js:4:19)
at handler (/var/task/node_modules/lambda-formation/lib/project/handler.js:41:49)
at module.exports.handler (/var/task/index.js:5:18)
```